### PR TITLE
fix: make db:importFromFile and db:getFromBackup non-interactive and FK-safe

### DIFF
--- a/src/Commands/DatabaseGetFromBackupCommand.php
+++ b/src/Commands/DatabaseGetFromBackupCommand.php
@@ -216,7 +216,10 @@ class DatabaseGetFromBackupCommand extends DatabaseCommand
     private function execUnzip(string $filename): void
     {
         $sourceFile = $filename[0] === DIRECTORY_SEPARATOR ? $filename : $this->storagePath($filename);
-        exec(sprintf('unzip %s -d %s', $sourceFile, $this->storagePath()));
+        // -o forces overwrite of any existing extracted file without prompting.
+        // Without it, re-runs (or downloads of archives whose contents already exist
+        // on disk) deadlock because unzip awaits an interactive answer on stdin.
+        exec(sprintf('unzip -o %s -d %s', $sourceFile, $this->storagePath()));
     }
 
     private function isZipFile(string $file): bool

--- a/src/Commands/DatabaseImportFromFileCommand.php
+++ b/src/Commands/DatabaseImportFromFileCommand.php
@@ -239,6 +239,11 @@ class DatabaseImportFromFileCommand extends DatabaseCommand
         ];
         $command[] = $connection['database'];
         $command[] = '--binary-mode';
+        // The dump file's own `SET FOREIGN_KEY_CHECKS=0` is not always honoured early
+        // enough by MariaDB to allow a CREATE TABLE that references a not-yet-created
+        // table (mysqldump emits tables alphabetically). Disabling at session start
+        // via --init-command guarantees the import succeeds regardless of order.
+        $command[] = '--init-command="SET SESSION FOREIGN_KEY_CHECKS=0; SET SESSION UNIQUE_CHECKS=0"';
         $command = implode(' ', $command);
         $process = Process::fromShellCommandline($command);
         $process->setInput($importFileHandle);


### PR DESCRIPTION
## Summary

Two independent bug fixes encountered while running the end-to-end
`db:getFromBackup` -> `db:importFromFile` flow against a MariaDB 10.6 target
with an `spatie/laravel-backup` archive that already exists locally.

### 1. `db:importFromFile`: FK_CHECKS not actually disabled for the spawned mysql process

`DatabaseImportFromFileCommand::handle()` calls
`Schema::disableForeignKeyConstraints()` (via `setForeignKeyCheckOff()`) on the
framework's database connection, but `databaseImportUsingCommandLine()` then
spawns a **separate** `mysql` CLI process - the disable does not carry over.

In theory the dump file itself takes care of this via the standard mysqldump
header:

```sql
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
```

In practice, on MariaDB 10.6 with `innodb_strict_mode=ON`, the first
`CREATE TABLE` that references a not-yet-created table (mysqldump emits
tables alphabetically, e.g. `apis` -> `modules`) still aborts with:

```
ERROR 1005 (HY000) at line 23050: Can't create table `db`.`apis`
(errno: 150 "Foreign key constraint is incorrectly formed")
```

The simplest reliable fix is to pass `--init-command` so the session-level
disable is in effect **before** any DDL is parsed:

```php
$command[] = '--init-command="SET SESSION FOREIGN_KEY_CHECKS=0; SET SESSION UNIQUE_CHECKS=0"';
```

After this change the same dump imports cleanly (~12s for ~130 MB, 90 tables).

### 2. `db:getFromBackup`: unzip prompts interactively, masking failure / hanging the command

`DatabaseGetFromBackupCommand::execUnzip()` invokes `unzip` without the
overwrite flag. When the archive's contents already exist on disk - the
common case for re-runs after a partial fetch, or when
`storage/db-dumps/mysql-<db>.sql` already exists from a previous extraction -
`unzip` prompts on stdin:

```
replace storage/db-dumps/mysql-foo.sql? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

`exec()` has no attached terminal, so EOF is treated as `[N]one` and the
archive is silently skipped, masking the failure. When artisan output is
piped (e.g. through `tail`), the parent process appears to hang indefinitely
waiting for the answer.

Adding `-o` makes unzip overwrite silently, matching the non-interactive
contract of an artisan command.

## Changes

- `src/Commands/DatabaseImportFromFileCommand.php`: add `--init-command` flag.
- `src/Commands/DatabaseGetFromBackupCommand.php`: add `-o` to unzip invocation.

## Test plan

- [x] `composer pint-test` -> passed
- [x] `composer phpstan` -> No errors
- [x] End-to-end: `db:getFromBackup` re-run with a pre-existing local SQL no longer hangs.
- [x] End-to-end: `db:importFromFile` on a fresh DB succeeds against the same archive that previously failed with errno 150.
- [ ] CI: existing PHPUnit suite (no test changes; both commands are not yet covered).

Made with [Cursor](https://cursor.com)